### PR TITLE
[Sprint2] 팀 관리, 마이페이지, webhook  기능, agent 서버 pulling 가능하도록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5' // jwt 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-webflux' //webclient 사용을 위한 webflux 의존성
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/logmate/agentConfig/AgentConfigService.java
+++ b/src/main/java/com/logmate/agentConfig/AgentConfigService.java
@@ -1,0 +1,34 @@
+package com.logmate.agentConfig;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logmate.agentConfig.dto.ConfigDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AgentConfigService {
+
+    private final AgentConfigurationRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public void saveConfig(ConfigDTO configDTO) {
+        try {
+            String json = objectMapper.writeValueAsString(configDTO);
+            String etag = UUID.randomUUID().toString(); // 새로운 etag 생성
+
+            AgentConfiguration config = new AgentConfiguration(
+                    configDTO.getAgentConfig().getAgentId(),
+                    etag,
+                    json
+            );
+
+            repository.save(config);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Config 저장 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/logmate/agentConfig/AgentConfiguration.java
+++ b/src/main/java/com/logmate/agentConfig/AgentConfiguration.java
@@ -1,0 +1,36 @@
+package com.logmate.agentConfig;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "agent_configurations")
+@Getter
+@NoArgsConstructor
+public class AgentConfiguration {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String agentId;
+
+    @Column(nullable = false)
+    private String etag;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String configJson; //ConfigDTO 전체를 JSON으로 저장
+
+    private LocalDateTime createdAt;
+
+    public AgentConfiguration(String agentId, String etag, String configJson) {
+        this.agentId = agentId;
+        this.etag = etag;
+        this.configJson = configJson;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/logmate/agentConfig/AgentConfigurationRepository.java
+++ b/src/main/java/com/logmate/agentConfig/AgentConfigurationRepository.java
@@ -1,0 +1,9 @@
+package com.logmate.agentConfig;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AgentConfigurationRepository extends JpaRepository<AgentConfiguration, Long> {
+    Optional<AgentConfiguration> findTopByAgentIdOrderByCreatedAtDesc(String agentId);
+}

--- a/src/main/java/com/logmate/agentConfig/controller/AgentConfigController.java
+++ b/src/main/java/com/logmate/agentConfig/controller/AgentConfigController.java
@@ -1,0 +1,45 @@
+package com.logmate.agentConfig.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logmate.agentConfig.dto.ConfigDTO;
+import com.logmate.agentConfig.model.AgentConfiguration;
+import com.logmate.agentConfig.repository.AgentConfigurationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/agents")
+@RequiredArgsConstructor
+public class AgentConfigController {
+
+    private final AgentConfigurationRepository repository;
+    private final ObjectMapper objectMapper;
+
+    @GetMapping("/config")
+    public ResponseEntity<?> getConfig(
+            @RequestParam String agentId,
+            @RequestParam String eTag,
+            @RequestHeader("Authorization") String token // 토큰 검증 로직 따로
+    ) {
+        AgentConfiguration config = repository.findTopByAgentIdOrderByCreatedAtDesc(agentId)
+                .orElse(null);
+
+        if (config == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Agent 설정 없음");
+        }
+
+        if (config.getEtag().equals(eTag)) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build(); // 304
+        }
+
+        try {
+            ConfigDTO dto = objectMapper.readValue(config.getConfigJson(), ConfigDTO.class);
+            return ResponseEntity.ok(dto); // 200 OK + JSON
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Config 파싱 실패");
+        }
+    }
+}
+

--- a/src/main/java/com/logmate/agentConfig/dto/AgentConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/AgentConfig.java
@@ -1,0 +1,11 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+
+
+@Data
+public class AgentConfig {
+    private String agentId;
+    private String accessToken;
+    private String etag;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/ConfigDTO.java
+++ b/src/main/java/com/logmate/agentConfig/dto/ConfigDTO.java
@@ -1,0 +1,12 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class ConfigDTO {
+    private String etag;
+    private AgentConfig agentConfig;
+    private PullerConfig pullerConfig;
+    private List<WatcherConfig> watcherConfigs;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/ExporterConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/ExporterConfig.java
@@ -1,0 +1,12 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+
+
+@Data
+public class ExporterConfig {
+    private String pushURL;
+    private Boolean compressEnabled;
+    private int retryIntervalSec;
+    private int maxRetryCount;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/FilterConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/FilterConfig.java
@@ -1,0 +1,22 @@
+package com.logmate.agentConfig.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.function.Predicate;
+
+
+@Data
+public class FilterConfig {
+    private Set<String> allowedLevels;
+    private Set<String> allowedLoggers;
+    private Set<String> requiredKeywords;
+    private LocalDateTime after;
+
+
+    @JsonIgnore
+    private Predicate<Object> customPredicate;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/MultilineConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/MultilineConfig.java
@@ -1,0 +1,9 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+
+@Data
+public class MultilineConfig {
+    private boolean enabled;
+    private int maxLines;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/ParserConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/ParserConfig.java
@@ -1,0 +1,11 @@
+package com.logmate.agentConfig.dto;
+
+
+import lombok.Data;
+
+
+@Data
+public class ParserConfig {
+    private String type;
+    private ParserDetailConfig config;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/ParserDetailConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/ParserDetailConfig.java
@@ -1,0 +1,14 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParserDetailConfig {
+    private String timestampPattern;
+    private String timezone;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/PullerConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/PullerConfig.java
@@ -1,0 +1,11 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+
+
+@Data
+public class PullerConfig {
+    private String pullURL;
+    private int intervalSec;
+    private String etag;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/TailerConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/TailerConfig.java
@@ -1,0 +1,11 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+
+
+@Data
+public class TailerConfig {
+    private String filePath;
+    private int readIntervalMs;
+    private String metaDataFilePathPrefix;
+}

--- a/src/main/java/com/logmate/agentConfig/dto/WatcherConfig.java
+++ b/src/main/java/com/logmate/agentConfig/dto/WatcherConfig.java
@@ -1,0 +1,15 @@
+package com.logmate.agentConfig.dto;
+
+import lombok.Data;
+
+
+@Data
+public class WatcherConfig {
+    private String etag;
+    private Integer thNum;
+    private TailerConfig tailer;
+    private MultilineConfig multiline;
+    private ExporterConfig exporter;
+    private ParserConfig parser;
+    private FilterConfig filter;
+}

--- a/src/main/java/com/logmate/agentConfig/model/AgentConfiguration.java
+++ b/src/main/java/com/logmate/agentConfig/model/AgentConfiguration.java
@@ -1,4 +1,4 @@
-package com.logmate.agentConfig;
+package com.logmate.agentConfig.model;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/logmate/agentConfig/repository/AgentConfigurationRepository.java
+++ b/src/main/java/com/logmate/agentConfig/repository/AgentConfigurationRepository.java
@@ -1,5 +1,6 @@
-package com.logmate.agentConfig;
+package com.logmate.agentConfig.repository;
 
+import com.logmate.agentConfig.model.AgentConfiguration;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/logmate/agentConfig/service/AgentConfigService.java
+++ b/src/main/java/com/logmate/agentConfig/service/AgentConfigService.java
@@ -1,8 +1,10 @@
-package com.logmate.agentConfig;
+package com.logmate.agentConfig.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logmate.agentConfig.repository.AgentConfigurationRepository;
 import com.logmate.agentConfig.dto.ConfigDTO;
+import com.logmate.agentConfig.model.AgentConfiguration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/logmate/auth/util/JwtUtil.java
+++ b/src/main/java/com/logmate/auth/util/JwtUtil.java
@@ -3,6 +3,7 @@ package com.logmate.auth.util;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -36,4 +37,9 @@ public class JwtUtil {
             throw new RuntimeException("Invalid JWT token");
         }
     }
+    public String extractEmailFromRequest(HttpServletRequest request) {
+        String token = request.getHeader("Authorization").substring(7);
+        return validateAndGetEmail(token);
+    }
+
 }

--- a/src/main/java/com/logmate/config/SecurityConfig.java
+++ b/src/main/java/com/logmate/config/SecurityConfig.java
@@ -13,7 +13,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 public class SecurityConfig {
 
-    @Bean
+    /*@Bean
     public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 서버)
@@ -23,6 +23,21 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(Customizer.withDefaults()); // 테스트용 basic 로그인 허용
+
+        return http.build();
+    }*/
+    // 프론트 연동을 위해 임시로 로그인 X
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 서버)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/users/**").permitAll() // 회원가입/로그인 허용
+                        .anyRequest().authenticated()                   // 전체 허용
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .formLogin(form -> form.disable())    // 기본 폼 로그인 끄기
+                .httpBasic(basic -> basic.disable()); // 기본 BasicAuth 끄기
 
         return http.build();
     }

--- a/src/main/java/com/logmate/dashboard/service/DashboardService.java
+++ b/src/main/java/com/logmate/dashboard/service/DashboardService.java
@@ -1,5 +1,7 @@
 package com.logmate.dashboard.service;
 
+import com.logmate.agentConfig.dto.*;
+import com.logmate.agentConfig.service.AgentConfigService;
 import com.logmate.dashboard.dto.DashboardRequest;
 import com.logmate.dashboard.dto.DashboardDto;
 import com.logmate.dashboard.model.Dashboard;
@@ -9,13 +11,17 @@ import com.logmate.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class DashboardService {
     private final DashboardRepository dashboardRepository;
     private final TeamRepository teamRepository;
+    private final AgentConfigService agentConfigService;
 
     public List<DashboardDto> getDashboardsByTeam(Long teamId) {
         return dashboardRepository.findByTeamId(teamId).stream()
@@ -34,7 +40,9 @@ public class DashboardService {
                 .team(team)
                 .build();
 
-        dashboardRepository.save(dashboard);
+        //dashboardRepository.save(dashboard);
+        ConfigDTO configDTO = makeConfigFromDashboard(dashboard, team);
+        agentConfigService.saveConfig(configDTO);
 
         return DashboardDto.from(dashboard);
     }
@@ -54,5 +62,63 @@ public class DashboardService {
         dashboardRepository.save(dashboard);
 
         return DashboardDto.from(dashboard);
+    }
+
+    private ConfigDTO makeConfigFromDashboard(Dashboard dashboard, Team team) {
+        AgentConfig agentConfig = new AgentConfig();
+        agentConfig.setAgentId("agent-" + team.getId()); // 팀 ID 기반 식별자
+        agentConfig.setAccessToken(null); // 아직 발급 안했으면 null 또는 "" 처리
+        agentConfig.setEtag(UUID.randomUUID().toString());
+
+        PullerConfig pullerConfig = new PullerConfig();
+        pullerConfig.setPullURL("http://localhost:8080/api/agents/config");
+        pullerConfig.setIntervalSec(30); // 기본값
+        pullerConfig.setEtag(UUID.randomUUID().toString());
+
+        WatcherConfig watcher = new WatcherConfig();
+        watcher.setEtag(UUID.randomUUID().toString());
+        watcher.setThNum(1); //기본값 1스레드
+
+        TailerConfig tailer = new TailerConfig();
+        tailer.setFilePath(dashboard.getLogPath());
+        tailer.setReadIntervalMs(1000);
+        tailer.setMetaDataFilePathPrefix("/var/log/meta"); // 고정값
+
+        watcher.setTailer(tailer);
+
+        MultilineConfig multiline = new MultilineConfig();
+        multiline.setEnabled(true);
+        multiline.setMaxLines(10);
+        watcher.setMultiline(multiline);
+
+        ExporterConfig exporter = new ExporterConfig();
+        exporter.setPushURL(dashboard.getSendUrl()); // 대시보드에 등록된 전송 URL
+        exporter.setCompressEnabled(true);
+        exporter.setRetryIntervalSec(5);
+        exporter.setMaxRetryCount(3);
+        watcher.setExporter(exporter);
+
+        ParserDetailConfig parserDetail = new ParserDetailConfig("yyyy-MM-dd HH:mm:ss", "Asia/Seoul");
+        ParserConfig parser = new ParserConfig();
+        parser.setType("springboot");
+        parser.setConfig(parserDetail);
+        watcher.setParser(parser);
+
+        FilterConfig filter = new FilterConfig();
+        filter.setAllowedLevels(Set.of("ERROR", "WARN"));
+        filter.setAllowedLoggers(Set.of());
+        filter.setRequiredKeywords(Set.of());
+        filter.setAfter(LocalDateTime.now().minusDays(1)); // 최근 하루 기준
+
+        watcher.setFilter(filter);
+
+        // 4. ConfigDTO 조립
+        ConfigDTO configDTO = new ConfigDTO();
+        configDTO.setEtag("config-dto-etag-" + UUID.randomUUID());
+        configDTO.setAgentConfig(agentConfig);
+        configDTO.setPullerConfig(pullerConfig);
+        configDTO.setWatcherConfigs(List.of(watcher));
+
+        return configDTO;
     }
 }

--- a/src/main/java/com/logmate/team/controller/TeamController.java
+++ b/src/main/java/com/logmate/team/controller/TeamController.java
@@ -1,6 +1,8 @@
 package com.logmate.team.controller;
 
 
+import com.logmate.team.dto.UpdateTeamMemberRoleRequest;
+import com.logmate.team.dto.UpdateTeamRequest;
 import com.logmate.team.service.TeamService;
 import com.logmate.team.dto.CreateTeamRequest;
 import com.logmate.team.dto.TeamDto;
@@ -37,7 +39,27 @@ public class TeamController {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("사용자 없음"));
 
-        TeamDto created = teamService.createTeam(request.getName(), user);
+        TeamDto created = teamService.createTeam(request, user);
         return ResponseEntity.ok(created);
+    }
+
+    @PutMapping("/{teamId}")
+    public ResponseEntity<TeamDto> updateTeam(@PathVariable Long teamId,
+                                              @RequestBody UpdateTeamRequest request) {
+        TeamDto updated = teamService.updateTeam(teamId, request);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping("/{teamId}/members/role")
+    public ResponseEntity<Void> updateMemberRole(@PathVariable Long teamId,
+                                                 @RequestBody UpdateTeamMemberRoleRequest request) {
+        teamService.updateTeamMemberRole(teamId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{teamId}/invite")
+    public ResponseEntity<String> getInviteUrl(@PathVariable Long teamId) {
+        String url = teamService.generateInviteUrl(teamId);
+        return ResponseEntity.ok(url);
     }
 }

--- a/src/main/java/com/logmate/team/dto/CreateTeamRequest.java
+++ b/src/main/java/com/logmate/team/dto/CreateTeamRequest.java
@@ -2,7 +2,11 @@ package com.logmate.team.dto;
 
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class CreateTeamRequest {
     private String name;
+    private String description;
+    private List<Long> memberIds;
 }

--- a/src/main/java/com/logmate/team/dto/UpdateTeamMemberRoleRequest.java
+++ b/src/main/java/com/logmate/team/dto/UpdateTeamMemberRoleRequest.java
@@ -1,0 +1,9 @@
+package com.logmate.team.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateTeamMemberRoleRequest {
+    private Long userId;
+    private String role; // "MEMBER", "MANAGER", "OWNER"
+}

--- a/src/main/java/com/logmate/team/dto/UpdateTeamRequest.java
+++ b/src/main/java/com/logmate/team/dto/UpdateTeamRequest.java
@@ -1,0 +1,10 @@
+package com.logmate.team.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateTeamRequest
+{
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/logmate/team/model/Team.java
+++ b/src/main/java/com/logmate/team/model/Team.java
@@ -20,6 +20,8 @@ public class Team {
 
     private String name;
 
+    private String description;
+
     // 팀 <-> 멤버 : teamMember 통해 연결
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL,  orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/com/logmate/team/model/TeamMember.java
+++ b/src/main/java/com/logmate/team/model/TeamMember.java
@@ -25,4 +25,10 @@ public class TeamMember {
     private User user;
 
     private String role; // TODO 협의 필요: 관리자인지 멤버인지
+
+    public TeamMember(Team team, User user, String role) {
+        this.team = team;
+        this.user = user;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/logmate/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/logmate/team/repository/TeamMemberRepository.java
@@ -5,8 +5,10 @@ import com.logmate.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     // 유저가 속한 팀 리스트
     List<TeamMember> findByUser(User user);
+    Optional<TeamMember> findByUserIdAndTeamId(Long userId, Long teamId);
 }

--- a/src/main/java/com/logmate/user/controller/UserController.java
+++ b/src/main/java/com/logmate/user/controller/UserController.java
@@ -2,16 +2,15 @@ package com.logmate.user.controller;
 
 import com.logmate.auth.dto.LoginRequest;
 import com.logmate.auth.dto.LoginResponse;
+import com.logmate.auth.util.JwtUtil;
 import com.logmate.auth.util.TokenBlacklist;
+import com.logmate.user.dto.UpdateUserRequest;
 import com.logmate.user.service.UserService;
 import com.logmate.user.model.User;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -20,6 +19,7 @@ public class UserController {
 
     private final UserService userService;
     private final TokenBlacklist tokenBlacklist;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@RequestBody User user) {
@@ -44,5 +44,27 @@ public class UserController {
         }
 
         return ResponseEntity.badRequest().body("토큰 없음");
+    }
+
+    @GetMapping("/mypage")
+    public ResponseEntity<?> getMyPage(HttpServletRequest request) {
+        String email = jwtUtil.extractEmailFromRequest(request);
+        User user = userService.getUserByEmail(email);
+        return ResponseEntity.ok(user);
+    }
+
+    @PatchMapping("/mypage")
+    public ResponseEntity<?> updateMyProfile(@RequestBody UpdateUserRequest request, HttpServletRequest httpRequest) {
+        String currentEmail = jwtUtil.extractEmailFromRequest(httpRequest);
+        userService.updateUser(currentEmail, request);
+        return ResponseEntity.ok("수정 완료");
+    }
+
+    //TODO soft delete 실행 유무 협의
+    @DeleteMapping("/mypage")
+    public ResponseEntity<?> deleteMyAccount(HttpServletRequest httpRequest) {
+        String email = jwtUtil.extractEmailFromRequest(httpRequest);
+        userService.deleteUser(email);
+        return ResponseEntity.ok("계정 탈퇴 와료");
     }
 }

--- a/src/main/java/com/logmate/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/logmate/user/dto/UpdateUserRequest.java
@@ -1,0 +1,9 @@
+package com.logmate.user.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdateUserRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/logmate/user/model/User.java
+++ b/src/main/java/com/logmate/user/model/User.java
@@ -2,9 +2,13 @@ package com.logmate.user.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "users")
+@SQLDelete(sql = "UPDATE users SET active = false WHERE id = ?")
+@Where(clause = "active = true")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -22,4 +26,7 @@ public class User {
     private String password;
 
     private String name;
+
+    @Column(nullable = false)
+    private boolean active = true;
 }

--- a/src/main/java/com/logmate/user/repository/UserRepository.java
+++ b/src/main/java/com/logmate/user/repository/UserRepository.java
@@ -2,10 +2,13 @@ package com.logmate.user.repository;
 
 import com.logmate.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
-}
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmailIncludingInactive(@Param("email") String email);}

--- a/src/main/java/com/logmate/webhook/dto/WebhookRequestDto.java
+++ b/src/main/java/com/logmate/webhook/dto/WebhookRequestDto.java
@@ -1,0 +1,14 @@
+package com.logmate.webhook.dto;
+
+import com.logmate.webhook.model.WebhookType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WebhookRequestDto {
+    private WebhookType type;
+    private String url;
+}

--- a/src/main/java/com/logmate/webhook/dto/WebhookResponseDto.java
+++ b/src/main/java/com/logmate/webhook/dto/WebhookResponseDto.java
@@ -1,0 +1,16 @@
+package com.logmate.webhook.dto;
+
+import com.logmate.webhook.model.WebhookType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WebhookResponseDto {
+    private Long id;
+    private WebhookType type;
+    private String url;
+    private boolean active;
+}

--- a/src/main/java/com/logmate/webhook/model/Webhook.java
+++ b/src/main/java/com/logmate/webhook/model/Webhook.java
@@ -1,0 +1,24 @@
+package com.logmate.webhook.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Webhook {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //팀 id or 사용자 id
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private WebhookType type; // SLACK, DISCORD, CUSTOM
+
+    private String url;
+
+    private boolean active = true;
+}

--- a/src/main/java/com/logmate/webhook/model/WebhookType.java
+++ b/src/main/java/com/logmate/webhook/model/WebhookType.java
@@ -1,0 +1,5 @@
+package com.logmate.webhook.model;
+
+public enum WebhookType {
+    SLACK, DISCORD, CUSTOM
+}

--- a/src/main/java/com/logmate/webhook/repository/WebhookRepository.java
+++ b/src/main/java/com/logmate/webhook/repository/WebhookRepository.java
@@ -1,0 +1,10 @@
+package com.logmate.webhook.repository;
+
+import com.logmate.webhook.model.Webhook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WebhookRepository extends JpaRepository<Webhook,Long> {
+    List<Webhook> findByUserIdAndActiveTrue(Long userId);
+}

--- a/src/main/java/com/logmate/webhook/service/WebhookService.java
+++ b/src/main/java/com/logmate/webhook/service/WebhookService.java
@@ -1,0 +1,83 @@
+package com.logmate.webhook.service;
+
+import com.logmate.webhook.dto.WebhookRequestDto;
+import com.logmate.webhook.dto.WebhookResponseDto;
+import com.logmate.webhook.model.Webhook;
+import com.logmate.webhook.repository.WebhookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookService {
+
+    private final WebhookRepository webhookRepository;
+
+    public WebhookResponseDto register(Long userId, WebhookRequestDto dto) {
+        if (!isValidUrl(dto.getUrl())) {
+            throw new IllegalArgumentException("유효하지 않은 URL입니다.");
+        }
+
+        Webhook webhook = new Webhook();
+        webhook.setUserId(userId);
+        webhook.setType(dto.getType());
+        webhook.setUrl(dto.getUrl());
+
+        Webhook saved = webhookRepository.save(webhook);
+        return new WebhookResponseDto(
+                saved.getId(),
+                saved.getType(),
+                saved.getUrl(),
+                saved.isActive()
+        );
+    }
+
+    private boolean isValidUrl(String url) {
+        try {
+            URI uri = new URI(url);
+            return uri.getScheme().startsWith("http");
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    public void testSend(String url) {
+        WebClient.create()
+                .post()
+                .uri(url)
+                .bodyValue(Map.of("text", "Webhook 테스트 메시지입니다."))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    //웹훅 알림 전송 메서드
+    public void sendEventToUserWebhooks(Long userId, String message) {
+        List<Webhook> webhooks = webhookRepository.findByUserIdAndActiveTrue(userId);
+
+        for (Webhook webhook : webhooks) {
+            try {
+                WebClient.create()
+                        .post()
+                        .uri(webhook.getUrl())
+                        .bodyValue(Map.of("text", message))
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+
+                log.info("Webhook 전송 성공: {}", webhook.getUrl());
+
+            } catch (Exception e) {
+                log.warn("Webhook 전송 실패: {}", webhook.getUrl(), e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 팀 관리
- 팀 정보 수정: 이름/설명 변경 요청 수신 및 갱신
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/5a3709ca-e192-4022-b7f9-3931cfa4f027" />

- 팀 멤버 권한 수정: ex) MEMBER, MANAGER, OWNER 등 역할 변경 & 해당 권한 부여
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/6c0f6621-8a52-4af7-9681-d3de445cef56" />

- 팀 초대 URL 발급: 고유한 초대 URL 반환
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/abd3e6b0-7fc6-4980-8adf-2bbfa230d901" />

- 팀 생성: 이름, 설명, 초기 멤버 정보 등을 수신하여 팀 생성 및 멤버 등록
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/9406feef-16e2-49fe-8770-89760b35bfb1" />


## 마이 페이지 
- 내 프로필 조회: 로그인 된 사용자 정보 반환
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/41c47efb-ec75-4448-bf81-1cd73b8a516e" />

- 내 정보 수정: 이메일/비밀번호/이름 등 변경 요청 수신 , 유효성 검사 수행 후 정보 갱신 
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/f7cbcd80-7240-4b55-810c-96362f3f4da0" />
- 유효성 검사 로직 : 현재는 이메일 중복 여부, 로그인 된 사용자 본인 확인 두가지만 되어 있는 상태
기능 명세서 참고하여 추가 예정 

- 계정 탈퇴: 사용자 데이터 비활성화 
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/d68a2b81-eca0-4a02-9307-58d361e90de3" />
<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/d59f30df-dc4d-46d9-b361-13b83daba2a8" />
- soft delete 방식을 적용하여 db상에서는 active 속성이 0이 되도록 구현


## Webhook URL 등록
- slack, discord, custom 세 가지 옵션 중, 사용자가 선택한 옵션으로 외부 알림용 URL 수신 -> 유효성 검사 수행 후 db 저장
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/e314f34c-b6c9-4fe9-8e4a-070d7eff96d9" />

---
### 고민 후 수정 예정인 사항
- 팀 정보 수정 시 멤버 수정도 함께 요청 보내야 하는지, 멤버 수정 api를 따로 구현해야하는지 고민중